### PR TITLE
Added support for optional section name

### DIFF
--- a/src/Rtl.Configuration.Validation/ConfigurationExtensions.cs
+++ b/src/Rtl.Configuration.Validation/ConfigurationExtensions.cs
@@ -7,9 +7,15 @@ namespace Rtl.Configuration.Validation
         public static T GetConfig<T>(this IConfiguration configuration, string sectionName)
             where T : class, new()
         {
-            var config = configuration.GetSection(sectionName).Get<T>();
+            return configuration.GetSection(sectionName).GetConfig<T>();
+        }
 
+        public static T GetConfig<T>(this IConfiguration configuration)
+            where T : class, new()
+        {
+            var config = configuration.Get<T>();
             var validator = new OptionsValidator<T>(config);
+
             validator.Validate();
 
             return config;

--- a/src/Rtl.Configuration.Validation/ServiceCollectionExtensions.cs
+++ b/src/Rtl.Configuration.Validation/ServiceCollectionExtensions.cs
@@ -8,7 +8,13 @@ namespace Rtl.Configuration.Validation
 {
     public static class ServiceCollectionExtensions
     {
-        public static IServiceCollection AddConfig<T>(this IServiceCollection services, IConfiguration configuration, string sectionName = null)
+        public static IServiceCollection AddConfig<T>(this IServiceCollection services, IConfiguration configuration, string sectionName)
+            where T : class, new()
+        {
+            return services.AddConfig<T>(configuration.GetSection(sectionName));
+        }
+
+        public static IServiceCollection AddConfig<T>(this IServiceCollection services, IConfiguration configuration)
             where T : class, new()
         {
             if (services.Any(x => x.ServiceType == typeof(IConfigureOptions<T>)))
@@ -21,9 +27,7 @@ namespace Rtl.Configuration.Validation
                 services.AddTransient<IStartupFilter, StartupFilter>();
             }
 
-            var config = sectionName != null ? configuration.GetSection(sectionName) : configuration;
-
-            services.Configure<T>(config);
+            services.Configure<T>(configuration);
             services.AddTransient<IOptionsValidator, OptionsValidator<T>>();
 
             return services;

--- a/src/Rtl.Configuration.Validation/ServiceCollectionExtensions.cs
+++ b/src/Rtl.Configuration.Validation/ServiceCollectionExtensions.cs
@@ -8,7 +8,7 @@ namespace Rtl.Configuration.Validation
 {
     public static class ServiceCollectionExtensions
     {
-        public static IServiceCollection AddConfig<T>(this IServiceCollection services, IConfiguration configuration, string sectionName)
+        public static IServiceCollection AddConfig<T>(this IServiceCollection services, IConfiguration configuration, string sectionName = null)
             where T : class, new()
         {
             if (services.Any(x => x.ServiceType == typeof(IConfigureOptions<T>)))
@@ -21,7 +21,9 @@ namespace Rtl.Configuration.Validation
                 services.AddTransient<IStartupFilter, StartupFilter>();
             }
 
-            services.Configure<T>(configuration.GetSection(sectionName));
+            var config = sectionName != null ? configuration.GetSection(sectionName) : configuration;
+
+            services.Configure<T>(config);
             services.AddTransient<IOptionsValidator, OptionsValidator<T>>();
 
             return services;


### PR DESCRIPTION
This PR allows for passing in just a configuration object without having to specify a section key. There are scenarios where the configuration object is not the root configuration, in which case it doesn't make sense to also have to specify a section key.

In fact, I think we should remove the `sectionKey` argument altogether and let the caller use configuration.GetSection.