### PR TITLE
Added support for configuring options through an Action<T> parameter

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -69,3 +69,19 @@ public static T GetConfig<T>(this IConfiguration configuration, string sectionNa
 ```
 Gets config of type `T` from configuration, validates and returns it.
 Use this method when you don't need to add IOptions and you want to get validated config inside `ConfigureServices` method and use right away
+
+#### Configure
+```csharp
+public static IServiceCollection Configure<T>(this IServiceCollection services, Action<T> configure)
+    where T : class, new()
+```
+Supports configuring your service through the provision of an `Action<T>` parameter. 
+
+Example usage:
+```csharp
+services.Configure(options => configuration.Bind(options));
+```
+Or:
+```csharp
+services.Configure(options => options.BaseAddress = new Uri("http://localhost:443"))
+```

--- a/src/Rtl.Configuration.Validation/ServiceCollectionExtensions.cs
+++ b/src/Rtl.Configuration.Validation/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -8,13 +9,23 @@ namespace Rtl.Configuration.Validation
 {
     public static class ServiceCollectionExtensions
     {
-        public static IServiceCollection AddConfig<T>(this IServiceCollection services, IConfiguration configuration, string sectionName)
+        public static IServiceCollection AddConfig<T>(this IServiceCollection services, IConfiguration configuration,
+            string sectionName)
             where T : class, new()
         {
             return services.AddConfig<T>(configuration.GetSection(sectionName));
         }
 
         public static IServiceCollection AddConfig<T>(this IServiceCollection services, IConfiguration configuration)
+            where T : class, new()
+        {
+            services.ConfigureWithValidation<T>(options => configuration.Bind(options));
+
+            return services;
+        }
+
+        public static IServiceCollection ConfigureWithValidation<T>(this IServiceCollection services,
+            Action<T> configure)
             where T : class, new()
         {
             if (services.Any(x => x.ServiceType == typeof(IConfigureOptions<T>)))
@@ -27,7 +38,7 @@ namespace Rtl.Configuration.Validation
                 services.AddTransient<IStartupFilter, StartupFilter>();
             }
 
-            services.Configure<T>(configuration);
+            services.Configure(configure);
             services.AddTransient<IOptionsValidator, OptionsValidator<T>>();
 
             return services;

--- a/src/Rtl.Configuration.Validation/ServiceCollectionExtensions.cs
+++ b/src/Rtl.Configuration.Validation/ServiceCollectionExtensions.cs
@@ -9,8 +9,7 @@ namespace Rtl.Configuration.Validation
 {
     public static class ServiceCollectionExtensions
     {
-        public static IServiceCollection AddConfig<T>(this IServiceCollection services, IConfiguration configuration,
-            string sectionName)
+        public static IServiceCollection AddConfig<T>(this IServiceCollection services, IConfiguration configuration, string sectionName)
             where T : class, new()
         {
             return services.AddConfig<T>(configuration.GetSection(sectionName));
@@ -24,8 +23,7 @@ namespace Rtl.Configuration.Validation
             return services;
         }
 
-        public static IServiceCollection ConfigureWithValidation<T>(this IServiceCollection services,
-            Action<T> configure)
+        public static IServiceCollection ConfigureWithValidation<T>(this IServiceCollection services, Action<T> configure)
             where T : class, new()
         {
             if (services.Any(x => x.ServiceType == typeof(IConfigureOptions<T>)))

--- a/src/Rtl.Configuration.Validation/ServiceCollectionExtensions.cs
+++ b/src/Rtl.Configuration.Validation/ServiceCollectionExtensions.cs
@@ -18,9 +18,7 @@ namespace Rtl.Configuration.Validation
         public static IServiceCollection AddConfig<T>(this IServiceCollection services, IConfiguration configuration)
             where T : class, new()
         {
-            services.ConfigureWithValidation<T>(options => configuration.Bind(options));
-
-            return services;
+            return services.ConfigureWithValidation<T>(options => configuration.Bind(options));
         }
 
         public static IServiceCollection ConfigureWithValidation<T>(this IServiceCollection services, Action<T> configure)

--- a/tests/Rtl.Configuration.Validation.Tests/ConfigureTests.cs
+++ b/tests/Rtl.Configuration.Validation.Tests/ConfigureTests.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading.Tasks;
+using Rtl.Configuration.Validation.Tests.Configs;
+using Rtl.Configuration.Validation.Tests.Helpers;
+using Xunit;
+
+namespace Rtl.Configuration.Validation.Tests
+{
+    public class ConfigureTests
+    {
+        [Fact]
+        public async Task ConfigureServicesDoesntThrow()
+        {
+            await TestHelpers.ValidationSucceeds(null, services =>
+                services.ConfigureWithValidation<TestConfiguration>(option =>
+                {
+                    option.Name = "asd";
+                    option.Value = 5;
+                }));
+        }
+
+        [Fact]
+        public void ConfigureServicesThrows()
+        {
+            TestHelpers.ValidationThrows(null, services =>
+                services.ConfigureWithValidation<TestConfiguration>(option =>
+                    option.Name = string.Empty));
+        }
+    }
+}

--- a/tests/Rtl.Configuration.Validation.Tests/ConfigureWithValidationTests.cs
+++ b/tests/Rtl.Configuration.Validation.Tests/ConfigureWithValidationTests.cs
@@ -9,7 +9,7 @@ namespace Rtl.Configuration.Validation.Tests
     public class ConfigureTests
     {
         [Fact]
-        public async Task ConfigureServicesDoesntThrow()
+        public async Task ConfigureWithValidationDoesntThrow()
         {
             await TestHelpers.ValidationSucceeds(null, services =>
                 services.ConfigureWithValidation<TestConfiguration>(option =>
@@ -20,7 +20,7 @@ namespace Rtl.Configuration.Validation.Tests
         }
 
         [Fact]
-        public void ConfigureServicesThrows()
+        public void ConfigureWithValidationThrows()
         {
             TestHelpers.ValidationThrows(null, services =>
                 services.ConfigureWithValidation<TestConfiguration>(option =>

--- a/tests/Rtl.Configuration.Validation.Tests/Helpers/TestHelpers.cs
+++ b/tests/Rtl.Configuration.Validation.Tests/Helpers/TestHelpers.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Rtl.Configuration.Validation.Tests.Helpers
@@ -15,19 +16,26 @@ namespace Rtl.Configuration.Validation.Tests.Helpers
         public static void ValidationThrows<TConfig>(Dictionary<string, string> settings, string sectionName = "test")
             where TConfig : class, new()
         {
-            IConfiguration configuration = null;
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(settings)
+                .Build();
 
+            ValidationThrows(settings, services => services.AddConfig<TConfig>(configuration, sectionName));
+        }
+
+        public static void ValidationThrows(Dictionary<string, string> settings,
+            Action<IServiceCollection> configure)
+        {
             Assert.Throws<ValidationException>(() =>
             {
                 var webHost = WebHost.CreateDefaultBuilder()
                     .ConfigureAppConfiguration((hostingContext, config) =>
                     {
                         config.AddInMemoryCollection(settings);
-                        configuration = config.Build();
                     })
                     .ConfigureServices(services =>
                     {
-                        services.AddConfig<TConfig>(configuration, sectionName);
+                        configure(services);
                     })
                     .Configure(app =>
                     {
@@ -40,21 +48,30 @@ namespace Rtl.Configuration.Validation.Tests.Helpers
             });
         }
 
-        public static async Task ValidationSucceeds<TConfig>(Dictionary<string, string> settings, string sectionName = "test")
+        public static Task ValidationSucceeds<TConfig>(Dictionary<string, string> settings,
+            string sectionName = "test")
             where TConfig : class, new()
         {
-            IConfiguration configuration = null;
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(settings)
+                .Build();
+
+            return ValidationSucceeds(settings, services => services.AddConfig<TConfig>(configuration, sectionName));
+        }
+
+        public static async Task ValidationSucceeds(Dictionary<string, string> settings,
+            Action<IServiceCollection> configure)
+        {
             using (var cts = new CancellationTokenSource())
             {
                 var webHost = WebHost.CreateDefaultBuilder()
                     .ConfigureAppConfiguration((hostingContext, config) =>
                     {
                         config.AddInMemoryCollection(settings);
-                        configuration = config.Build();
                     })
                     .ConfigureServices(services =>
                     {
-                        services.AddConfig<TConfig>(configuration, sectionName);
+                        configure(services);
                     })
                     .Configure(app =>
                     {

--- a/tests/Rtl.Configuration.Validation.Tests/Helpers/TestHelpers.cs
+++ b/tests/Rtl.Configuration.Validation.Tests/Helpers/TestHelpers.cs
@@ -23,8 +23,7 @@ namespace Rtl.Configuration.Validation.Tests.Helpers
             ValidationThrows(settings, services => services.AddConfig<TConfig>(configuration, sectionName));
         }
 
-        public static void ValidationThrows(Dictionary<string, string> settings,
-            Action<IServiceCollection> configure)
+        public static void ValidationThrows(Dictionary<string, string> settings, Action<IServiceCollection> configure)
         {
             Assert.Throws<ValidationException>(() =>
             {
@@ -48,8 +47,7 @@ namespace Rtl.Configuration.Validation.Tests.Helpers
             });
         }
 
-        public static Task ValidationSucceeds<TConfig>(Dictionary<string, string> settings,
-            string sectionName = "test")
+        public static Task ValidationSucceeds<TConfig>(Dictionary<string, string> settings, string sectionName = "test")
             where TConfig : class, new()
         {
             IConfiguration configuration = new ConfigurationBuilder()
@@ -59,8 +57,7 @@ namespace Rtl.Configuration.Validation.Tests.Helpers
             return ValidationSucceeds(settings, services => services.AddConfig<TConfig>(configuration, sectionName));
         }
 
-        public static async Task ValidationSucceeds(Dictionary<string, string> settings,
-            Action<IServiceCollection> configure)
+        public static async Task ValidationSucceeds(Dictionary<string, string> settings, Action<IServiceCollection> configure)
         {
             using (var cts = new CancellationTokenSource())
             {


### PR DESCRIPTION
So there is this feature that we were still missing in our code, which is the possibility to configure settings through the Action<T> pattern (while preserving validation).

So with this we can use `services.ConfigureWithValidation(options => DoWhatever(options));`

Also includes some refactoring to make the test logic a bit cleaner while supporting some more variable syntax.